### PR TITLE
Modernize project setup

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,5 +1,0 @@
-[flake8]
-exclude = .git,.tox,__pycache__
-max-line-length = 100
-select = C,E,F,W,B,B950
-ignore = E501,W503,E203

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,16 @@
+name: Hassfest
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - develop
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"  # v4.3.1
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89  # master

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,21 @@
+name: mypy
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - develop
+  pull_request:
+
+jobs:
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          pip install mypy
+      - name: Run mypy
+        run: mypy custom_components/xiaomi_miio

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,17 @@
+name: pre-commit
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - develop
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.13"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,19 @@
+name: yamllint
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - develop
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
+        with:
+          config_file: .yamllint

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-python:
-  enabled: true
-  config_file: .flake8.ini

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,32 @@
 repos:
-- repo: https://github.com/ambv/black
-  rev: stable
-  hooks:
-  - id: black
-    language_version: python3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+        files: ^(custom_components)/.+\.py$
+      - id: ruff-format
+        files: ^(custom_components)/.+\.py$
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=hass,alot,datas,dof,dur,eto,farenheit,hist,iff,ines,ist,lightsensor,mut,nd,pres,referer,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,hsa
+          - --quiet-level=2
+        exclude_types: [csv, json, ini]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-executables-have-shebangs
+        stages: [manual]
+      - id: check-json
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.6.2
+          - prettier-plugin-sort-json@4.2.0
+        files: ^custom_components/.+\.json$

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,68 @@
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+ignore: |
+  /.cache/
+
+rules:
+  braces:
+    level: error
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    level: error
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    level: error
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: error
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    level: error
+    require-starting-space: true
+    min-spaces-from-content: 2
+  comments-indentation: disable
+  document-end:
+    level: error
+    present: false
+  document-start:
+    level: error
+    present: false
+  empty-lines:
+    level: error
+    max: 2
+    max-start: 0
+    max-end: 1
+  hyphens:
+    level: error
+    max-spaces-after: 1
+  indentation:
+    level: error
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates:
+    level: error
+  line-length: disable
+  new-line-at-end-of-file:
+    level: error
+  new-lines:
+    level: error
+    type: unix
+  trailing-spaces:
+    level: error
+  truthy:
+    level: error

--- a/custom_components/xiaomi_miio/__init__.py
+++ b/custom_components/xiaomi_miio/__init__.py
@@ -1,0 +1,1 @@
+"""Xiaomi Mi Air Quality Monitor custom component."""

--- a/custom_components/xiaomi_miio/manifest.json
+++ b/custom_components/xiaomi_miio/manifest.json
@@ -3,6 +3,8 @@
   "dependencies": [],
   "documentation": "https://github.com/syssi/xiaomi_airqualitymonitor",
   "domain": "xiaomi_miio",
+  "iot_class": "local_polling",
   "name": "Xiaomi Mi Air Quality Monitor (PM2.5)",
-  "requirements": ["construct==2.9.45", "python-miio==0.4.7"]
+  "requirements": ["construct==2.9.45", "python-miio==0.4.7"],
+  "version": "1.0.0"
 }

--- a/custom_components/xiaomi_miio/manifest.json
+++ b/custom_components/xiaomi_miio/manifest.json
@@ -5,6 +5,6 @@
   "domain": "xiaomi_miio",
   "iot_class": "local_polling",
   "name": "Xiaomi Mi Air Quality Monitor (PM2.5)",
-  "requirements": ["construct==2.9.45", "python-miio==0.4.7"],
+  "requirements": ["construct==2.10.68", "python-miio>=0.5.12"],
   "version": "1.0.0"
 }

--- a/custom_components/xiaomi_miio/manifest.json
+++ b/custom_components/xiaomi_miio/manifest.json
@@ -1,10 +1,10 @@
 {
+  "domain": "xiaomi_miio",
+  "name": "Xiaomi Mi Air Quality Monitor (PM2.5)",
   "codeowners": ["@syssi"],
   "dependencies": [],
   "documentation": "https://github.com/syssi/xiaomi_airqualitymonitor",
-  "domain": "xiaomi_miio",
   "iot_class": "local_polling",
-  "name": "Xiaomi Mi Air Quality Monitor (PM2.5)",
   "requirements": ["construct==2.10.68", "python-miio>=0.5.12"],
   "version": "1.0.0"
 }

--- a/custom_components/xiaomi_miio/sensor.py
+++ b/custom_components/xiaomi_miio/sensor.py
@@ -1,5 +1,4 @@
-"""
-Support for Xiaomi Mi Air Quality Monitor (PM2.5).
+"""Support for Xiaomi Mi Air Quality Monitor (PM2.5).
 
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/sensor.xiaomi_miio/
@@ -8,13 +7,13 @@ https://home-assistant.io/components/sensor.xiaomi_miio/
 from functools import partial
 import logging
 
-import voluptuous as vol
-
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_TOKEN
-from homeassistant.exceptions import PlatformNotReady
+from miio import AirQualityMonitor, DeviceException
+import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,8 +42,6 @@ SUCCESS = ["ok"]
 # pylint: disable=unused-argument
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the sensor from config."""
-    from miio import AirQualityMonitor, DeviceException
-
     if DATA_KEY not in hass.data:
         hass.data[DATA_KEY] = {}
 
@@ -58,7 +55,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
         air_quality_monitor = AirQualityMonitor(host, token)
         device_info = air_quality_monitor.info()
         model = device_info.model
-        unique_id = "{}-{}".format(model, device_info.mac_address)
+        unique_id = f"{model}-{device_info.mac_address}"
         _LOGGER.info(
             "%s %s %s detected",
             model,
@@ -67,7 +64,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
         )
         device = XiaomiAirQualityMonitor(name, air_quality_monitor, model, unique_id)
     except DeviceException:
-        raise PlatformNotReady
+        raise PlatformNotReady from None
 
     hass.data[DATA_KEY][host] = device
     async_add_devices([device], update_before_add=True)
@@ -137,8 +134,6 @@ class XiaomiAirQualityMonitor(Entity):
 
     async def _try_command(self, mask_error, func, *args, **kwargs):
         """Call a device command handling error messages."""
-        from miio import DeviceException
-
         try:
             result = await self.hass.async_add_job(partial(func, *args, **kwargs))
 
@@ -152,8 +147,6 @@ class XiaomiAirQualityMonitor(Entity):
 
     async def async_update(self):
         """Fetch state from the miio device."""
-        from miio import DeviceException
-
         try:
             state = await self.hass.async_add_job(self._device.status)
             _LOGGER.debug("Got new state: %s", state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.ruff]
+required-version = ">=0.15.17"
+
+[tool.ruff.lint]
+select = [
+  "B",      # flake8-bugbear
+  "D",      # docstrings
+  "E",      # pycodestyle
+  "F",      # pyflakes
+  "I",      # isort
+  "N",      # pep8-naming
+  "PL",     # pylint
+  "RUF",    # ruff-specific
+  "SIM",    # flake8-simplify
+  "UP",     # pyupgrade
+]
+ignore = [
+  "D202",   # No blank lines allowed after function docstring
+  "D203",   # 1 blank line required before class docstring
+  "D213",   # Multi-line docstring summary should start at the second line
+  "D406",   # Section name should end with a newline
+  "D407",   # Section name underlining
+  "E501",   # line too long
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments
+  "PLR0915", # Too many statements
+  "PLR2004", # Magic value in comparison
+  "N815",    # Variable in class scope should not be mixedCase
+  "RUF012",  # Mutable class attributes should be annotated with typing.ClassVar
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["custom_components.xiaomi_miio"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[mypy]
+python_version = 3.13
+follow_imports = silent
+ignore_missing_imports = true
+warn_incomplete_stub = true
+warn_redundant_casts = true
+warn_unused_configs = true


### PR DESCRIPTION
## Summary

- Replace `black` with `ruff` (ruff-check + ruff-format) in pre-commit hooks
- Add `codespell`, `pre-commit-hooks`, `prettier` (for JSON) to pre-commit
- Add `pyproject.toml` with ruff lint config — replaces `.flake8.ini`
- Add `setup.cfg` with mypy config
- Add `.yamllint` config
- Add GitHub Actions workflows: `hassfest`, `mypy`, `pre-commit`, `yamllint`
- Remove obsolete `.flake8.ini` and `.hound.yml`

No HACS workflow — this component is not in HACS.

Modeled after https://github.com/syssi/xiaomi_airpurifier/commits/develop/